### PR TITLE
feat(board): Add Event Listener Support for Board Actions

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -81,15 +81,19 @@ This document provides a comprehensive guide to the API of the Tridecco Game Boa
       - [Example](#example-31)
     - [`getCompleteHexagons()`](#getcompletehexagons)
       - [Example](#example-32)
-    - [`back(steps)`](#backsteps)
+    - [`addEventListener(event, callback)`](#addeventlistenerevent-callback)
       - [Example](#example-33)
-    - [`clear()`](#clear-1)
+    - [`removeEventListener(event, callback)`](#removeeventlistenerevent-callback)
       - [Example](#example-34)
+    - [`back(steps)`](#backsteps)
+      - [Example](#example-35)
+    - [`clear()`](#clear-1)
+      - [Example](#example-36)
   - [Game Piece](#game-piece)
     - [Constructor](#constructor-3)
-      - [Example](#example-35)
+      - [Example](#example-37)
     - [`equals(other)`](#equalsother)
-      - [Example](#example-36)
+      - [Example](#example-38)
 
 ## Import the Library
 
@@ -1083,6 +1087,77 @@ if (completeHexagons.length > 0) {
 } else {
   console.log('No complete hexagons on the board.');
 }
+```
+
+### `addEventListener(event, callback)`
+
+```javascript
+addEventListener(event, callback);
+```
+
+**Description:**
+
+Adds an event listener for a specific event on the board. This allows you to listen for events such as `set`, `remove`, and others that are triggered during the game. The callback function will be executed whenever the specified event occurs.
+
+**Parameters:**
+
+- `event` (string): The name of the event to listen for. Common events include:
+  - `'set'`: Triggered when a piece is set on the board.
+  - `'remove'`: Triggered when a piece is removed from the board.
+  - `'form'`: Triggered when a hexagon is formed after placing a piece.
+  - `'destroy'`: Triggered when a hexagon is destroyed (removed) from the board.
+- `callback` (Function): The callback function to execute when the event occurs.
+  - `'set'` event: The callback will be passed the following parameters:
+    - `index` (number): The index where the piece was set.
+    - `piece` (Piece): The piece that was set.
+  - `'remove'` event: The callback will be passed the following parameters:
+    - `index` (number): The index from which the piece was removed.
+    - `piece` (Piece | null): The piece that was removed (or `null` if no piece was present).
+  - `'form'` event: The callback will be passed the following parameters:
+    - `hexagons` (Array<Array<number>>): An array of hexagon coordinates that were formed as a result of placing the piece.
+  - `'destroy'` event: The callback will be passed the following parameters:
+    - `hexagons` (Array<Array<number>>): An array of hexagon coordinates that were destroyed.
+
+**Throws:**
+
+- `Error`: If the `event` parameter is not a valid event name.
+
+#### Example
+
+```javascript
+board.addEventListener('set', (index, piece) => {
+  console.log(`Piece set at index ${index} with piece:`, piece);
+});
+```
+
+### `removeEventListener(event, callback)`
+
+```javascript
+removeEventListener(event, callback);
+```
+
+**Description:**
+
+Removes an event listener for a specific event on the board. This stops the specified callback function from being executed when the event occurs.
+
+**Parameters:**
+
+- `event` (string): The name of the event to stop listening for. This should match the event name used when adding the listener.
+- `callback` (Function): The callback function to remove. This should be the same function that was passed to `addEventListener`.
+
+**Throws:**
+
+- `Error`: If the `event` parameter is not a valid event name.
+
+#### Example
+
+```javascript
+function handleSetEvent(index, piece) {
+  console.log(`Piece set at index ${index} with piece:`, piece);
+}
+board.addEventListener('set', handleSetEvent);
+// Later, if you want to remove the listener
+board.removeEventListener('set', handleSetEvent);
 ```
 
 ### `back(steps)`

--- a/tests/board.test.js
+++ b/tests/board.test.js
@@ -647,4 +647,99 @@ describe('Board', () => {
       expect(Array.from(board.hexagons)).toEqual([]);
     });
   });
+
+  describe('Board Event Listeners', () => {
+    let board;
+    let piece;
+
+    beforeEach(() => {
+      board = new Board();
+      piece = new Piece(['red', 'blue']);
+    });
+
+    describe('addEventListener', () => {
+      it('should add an event listener for a valid event type', () => {
+        const listener = jest.fn();
+        board.addEventListener('set', listener);
+        board.set(0, piece);
+        expect(listener).toHaveBeenCalledWith(0, piece);
+      });
+
+      it('should throw an error for an invalid event type', () => {
+        const listener = jest.fn();
+        expect(() => board.addEventListener('invalid', listener)).toThrowError(
+          'Invalid event type',
+        );
+      });
+    });
+
+    describe('removeEventListener', () => {
+      it('should remove an event listener for a valid event type', () => {
+        const listener = jest.fn();
+        board.addEventListener('set', listener);
+        board.removeEventListener('set', listener);
+        board.set(0, piece);
+        expect(listener).not.toHaveBeenCalled();
+      });
+
+      it('should throw an error for an invalid event type', () => {
+        const listener = jest.fn();
+        expect(() =>
+          board.removeEventListener('invalid', listener),
+        ).toThrowError('Invalid event type');
+      });
+    });
+
+    describe('Event Triggering', () => {
+      it('should trigger "set" event when a piece is set', () => {
+        const listener = jest.fn();
+        board.addEventListener('set', listener);
+        board.set(0, piece);
+        expect(listener).toHaveBeenCalledWith(0, piece);
+      });
+
+      it('should trigger "remove" event when a piece is removed', () => {
+        const listener = jest.fn();
+        board.addEventListener('remove', listener);
+        board.place(0, piece);
+        board.remove(0);
+        expect(listener).toHaveBeenCalledWith(0, piece);
+      });
+
+      it('should trigger "form" event when a hexagon is formed', () => {
+        const listener = jest.fn();
+        board.addEventListener('form', listener);
+        const piece1 = new Piece(['red', 'green']);
+        const piece2 = new Piece(['green', 'blue']);
+        board.place(0, piece1);
+        board.place(8, piece2);
+        expect(listener).toHaveBeenCalledWith([[1, 1]]);
+      });
+
+      it('should trigger "destroy" event when a hexagon is destroyed', () => {
+        const listener = jest.fn();
+        board.addEventListener('destroy', listener);
+        const piece1 = new Piece(['red', 'green']);
+        const piece2 = new Piece(['green', 'blue']);
+        board.place(0, piece1);
+        board.place(8, piece2);
+        board.remove(8);
+        expect(listener).toHaveBeenCalledWith([1, 1]);
+      });
+
+      it('should not trigger any events if is counting hexagons', () => {
+        const piece1 = new Piece(['red', 'green']);
+        board.place(0, piece1);
+
+        const listener = jest.fn();
+        board.addEventListener('set', listener);
+        board.addEventListener('remove', listener);
+        board.addEventListener('form', listener);
+        board.addEventListener('destroy', listener);
+        const piece2 = new Piece(['green', 'blue']);
+        board.countHexagonsFormed(8, piece2); // This should not trigger any events
+        expect(listener).not.toHaveBeenCalled();
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Summary:

Implemented event listener functionality for the `Board` class to allow external systems to react to key board actions in real-time. This includes support for adding and removing listeners for events such as adding a piece, removing a piece, forming a hexagon, and destroying a hexagon.

### Changes:

- **Added Event Listener Support:**
  - Implemented `addEventListener(event, callback)` to register listeners for specific events.
  - Implemented `removeEventListener(event, callback)` to unregister listeners for specific events.
  - Supported the following events:
    - **`set`**: Triggered when a piece is added to the board.
    - **`remove`**: Triggered when a piece is removed from the board.
    - **`form`**: Triggered when a hexagon is formed.
    - **`destroy`**: Triggered when a hexagon is destroyed.

- **Integrated Event Triggering:**
  - Triggered `set` event during the `set` method when a piece is added.
  - Triggered `remove` event during the `remove` method when a piece is removed.
  - Triggered `form` event during the `place` method when new hexagons are formed.
  - Triggered `destroy` event during the `remove` method when hexagons are destroyed.

- **Prevented Event Triggering During Hexagon Counting:**
  - Added a flag to suppress event triggering during `countHexagonsFormed` to avoid unintended side effects.

- **Developed Unit Tests:**
  - Verified that event listeners are correctly registered and unregistered.
  - Ensured events are triggered with the correct data during board actions.
  - Tested edge cases, such as invalid event types and event suppression during hexagon counting.

- **Updated Documentation:**
  - Documented the event listener API in `API.md`, including supported events, usage examples, and callback parameters.