### PR TITLE
fix(docs): Update version number in README, API, and ASSETS

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Tridecco Game Board is the game board and pieces for the Tridecco game. It is a 
 #### Node.js
 
 ```bash
-npm install tridecco-board@0.2.0
+npm install tridecco-board@0.2.2
 ```
 
 #### Browser
@@ -34,7 +34,7 @@ npm install tridecco-board@0.2.0
 Include the following script tag in your HTML file:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/tridecco-board@0.2.0/dist/tridecco-board.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/tridecco-board@0.2.2/dist/tridecco-board.min.js"></script>
 ```
 
 > **Note**: You can also download the `tridecco-board.min.js` file and include it in your project.

--- a/docs/API.md
+++ b/docs/API.md
@@ -159,7 +159,7 @@ const defaultRendererMap = Tridecco.maps.renderer.default;
 
 ```html
 <!-- Import the library -->
-<script src="https://cdn.jsdelivr.net/npm/tridecco-board@0.2.0/dist/tridecco-board.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/tridecco-board@0.2.2/dist/tridecco-board.min.js"></script>
 ```
 
 ```javascript

--- a/docs/ASSETS.md
+++ b/docs/ASSETS.md
@@ -68,7 +68,7 @@ All texture packs are located in the `assets/textures/` directory, organized by 
 
 For convenience, the available assets are also hosted on jsDelivr CDN:
 
-- **Base URL**: `https://cdn.jsdelivr.net/gh/tridecco/game-board@0.2.0/assets/`
+- **Base URL**: `https://cdn.jsdelivr.net/gh/tridecco/game-board@0.2.2/assets/`
 
 ## Customization
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -4,7 +4,7 @@
  */
 
 const DEFAULT_ASSETS_URL =
-  'https://cdn.jsdelivr.net/gh/tridecco/game-board@0.2.0/assets/';
+  'https://cdn.jsdelivr.net/gh/tridecco/game-board@0.2.2/assets/';
 
 const Board = require('./board');
 const TexturePack = require('./texturePack');


### PR DESCRIPTION
### Summary:

Updated the version number in `README.md`, API documentation, and ASSETS to match the latest npm package version `0.2.2`.

### Changes:

- **README.md:**
  - Updated npm install command to use version `0.2.2`.
  - Updated script tag URL to use version `0.2.2`.

- **API.md:**
  - Updated script tag URL to use version `0.2.2`.

- **ASSETS.md:**
  - Updated base URL to use version `0.2.2`.

- **renderer.js:**
  - Updated DEFAULT_ASSETS_URL to use version `0.2.2`.