### PR TITLE
fix(renderer): Update hexagon rendering to use coordinate and color properties

### DIFF
--- a/src/piece.js
+++ b/src/piece.js
@@ -11,7 +11,7 @@ class Piece {
    * @constructor
    * @param {Array<string>} colors - The colors of the piece.
    * @param {Object} [params={}] - Optional parameters for the piece.
-   * @throws {Error} If colors is not an array of 2 strings or if params is not an object.
+   * @throws {Error} - If colors is not an array of 2 strings or if params is not an object.
    */
   constructor(colors, params = {}) {
     const PIECE_COLOR_COUNT = 2;

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -648,7 +648,7 @@ class Renderer {
   _renderHexagons() {
     const hexagons = this.board.getCompleteHexagons();
     for (const hexagon of hexagons) {
-      this._renderHexagon(hexagon, 'hexagon'); // Assuming 'hexagon' is the color key for hexagons
+      this._renderHexagon(hexagon.coordinate, hexagon.color);
     }
   }
 


### PR DESCRIPTION
### Summary:

Resolves a **TypeError** in the `Renderer` class that occurred during hexagon redrawing, as reported in #16. The error was specifically triggered after canvas resizing, or calls to `updateTextures` or `updateMap`, indicating an issue with how hexagon rendering was handled after these events.  This fix updates the hexagon rendering logic to correctly utilize the `coordinate` and `color` properties of each hexagon object, ensuring accurate and consistent rendering, especially after context or data updates.

### Changes:

- **Updated Hexagon Rendering Logic:**
  - Modified the `_renderHexagons` method in `src/renderer.js` to correctly pass `hexagon.coordinate` and `hexagon.color` as arguments to the `_renderHexagon` function.
  - This change ensures that the hexagon rendering process now uses the actual coordinate and color information associated with each hexagon, rather than relying on a static or default color key.