### PR TITLE
feat(renderer): Implement Automatic Renderer Destruction on DOM Removal for Lifecycle Management

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -171,6 +171,24 @@ class Renderer {
     this._initEventListeners(); // Initialize event listeners
     this.eventHandlers = new Map();
 
+    this.isDestroyed = false; // Flag to check if the renderer is destroyed
+    this.mutationObserver = new MutationObserver((mutationsList, observer) => {
+      for (const mutation of mutationsList) {
+        if (mutation.removedNodes) {
+          mutation.removedNodes.forEach((removedNode) => {
+            if (removedNode === this.canvas || removedNode === this.container) {
+              this.destroy();
+              observer.disconnect();
+            }
+          });
+        }
+      }
+    });
+    this.mutationObserver.observe(this.container.parentNode || this.container, {
+      childList: true,
+      subtree: true,
+    });
+
     this._isPreviewing = false; // Flag to check if a piece is being previewed
     this._isShowingAvailablePositions = false; // Flag to check if available positions are being shown
     this._showingAvailablePositions = new Array(); // Store currently shown available positions

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -178,7 +178,6 @@ class Renderer {
           mutation.removedNodes.forEach((removedNode) => {
             if (removedNode === this.canvas || removedNode === this.container) {
               this.destroy();
-              observer.disconnect();
             }
           });
         }
@@ -1162,6 +1161,11 @@ class Renderer {
     // Stop observing the container resize
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();
+    }
+
+    // Stop observing mutation events
+    if (this.mutationObserver) {
+      this.mutationObserver.disconnect();
     }
 
     // Remove the canvas from the container

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -171,7 +171,6 @@ class Renderer {
     this._initEventListeners(); // Initialize event listeners
     this.eventHandlers = new Map();
 
-    this.isDestroyed = false; // Flag to check if the renderer is destroyed
     this.mutationObserver = new MutationObserver((mutationsList, observer) => {
       for (const mutation of mutationsList) {
         if (mutation.removedNodes) {
@@ -198,6 +197,8 @@ class Renderer {
       this._setUpCanvas();
       callback(this); // Call the callback function after loading assets and setting up the canvas
     });
+
+    this.isDestroyed = false; // Flag to check if the renderer is destroyed
   }
 
   /**
@@ -1137,6 +1138,10 @@ class Renderer {
    * @method destroy - Tears down the renderer, releasing resources, removing listeners, and detaching the canvas from the DOM.
    */
   destroy() {
+    if (this.isDestroyed) {
+      return; // Prevent double destruction
+    }
+
     // Remove event listeners from the board
     this.board.removeEventListener('set', this.eventHandlers.get('set'));
     this.board.removeEventListener('remove', this.eventHandlers.get('remove'));
@@ -1202,6 +1207,8 @@ class Renderer {
 
     this._previewingPositions.clear();
     this._previewingPositions = null;
+
+    this.isDestroyed = true; // Mark the renderer as destroyed
   }
 }
 


### PR DESCRIPTION
### Summary:

Introduces automatic lifecycle management by implementing automatic destruction of the `Renderer` instance when its associated canvas or container element is removed from the DOM. This enhancement ensures proper resource cleanup and prevents potential memory leaks by automatically invoking the existing `destroy()` method when the rendered board is no longer needed in the DOM.

### Changes:

- **Implemented DOM Monitoring with MutationObserver for Automatic Lifecycle Management:**
  - Integrated a `MutationObserver` into the `Renderer` class. This observer actively monitors the DOM for the removal of the Renderer's canvas or container element.
  - Upon detecting that the Renderer's elements are no longer part of the DOM, the `MutationObserver` automatically triggers the `destroy()` method of the `Renderer` instance.
  - This automation ensures that the Renderer's lifecycle is directly tied to its presence in the DOM, providing automatic cleanup without manual intervention.

- **Introduced `isDestroyed` Flag for Lifecycle State Tracking and Prevention of Redundant Destruction:**
  - Added an `isDestroyed` boolean flag to the `Renderer` class to track the destruction state of the instance.
  - The `destroy()` method now checks this flag at the beginning. If `isDestroyed` is already `true`, the method will immediately exit, preventing any attempts at double destruction and ensuring idempotent behavior.
  - This flag ensures that the destruction process is only executed once per instance, even if triggered multiple times (e.g., by the `MutationObserver` and potentially manual calls).

- **Enhanced `destroy()` Method to Encompass Full Resource Lifecycle Management:**
  - The `destroy()` method, now automatically invoked by the DOM monitoring system, is designed to comprehensively manage the Renderer's lifecycle by:
    - Reliably detaching all event listeners previously attached to the `Board` instance, preventing orphaned listeners.
    - Disconnecting the `ResizeObserver`, ensuring no further resize events are processed after destruction.
    - Disconnecting the `MutationObserver` itself, stopping further DOM monitoring by the destroyed instance.
    - Safely removing the canvas element from the DOM, detaching it from the visual tree.
    - Releasing references to internal data structures and objects, facilitating garbage collection and memory reclamation.