### PR TITLE
fix(renderer): Prevent Texture Loading Race Condition and Simplify Asset Loading

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -285,32 +285,11 @@ class AssetsManager {
    * @returns {Promise} - A promise that resolves when all assets are loaded.
    */
   async load() {
-    const texturePromise = new Promise((resolve, reject) => {
-      this.textures = new TexturePack(
-        this.urls.texturesIndex,
-        this.urls.texturesAtlas,
-        (error) => {
-          if (error) reject(error);
-          else resolve();
-        },
-      );
-    });
-
-    const backgroundPromise = new Promise((resolve, reject) => {
-      this.background = new Image();
-      this.background.onload = () => resolve();
-      this.background.onerror = reject;
-      this.background.src = this.urls.background;
-    });
-
-    const gridPromise = new Promise((resolve, reject) => {
-      this.grid = new Image();
-      this.grid.onload = () => resolve();
-      this.grid.onerror = reject;
-      this.grid.src = this.urls.grid;
-    });
-
-    return Promise.all([texturePromise, backgroundPromise, gridPromise]);
+    return Promise.all([
+      this.updateTextures(this.urls.texturesIndex, this.urls.texturesAtlas),
+      this.updateBackground(this.urls.background),
+      this.updateGrid(this.urls.grid),
+    ]);
   }
 
   /**

--- a/src/texturePack.js
+++ b/src/texturePack.js
@@ -61,7 +61,6 @@ class TexturePack {
 
         const img = new Image();
         img.crossOrigin = 'anonymous'; // Set crossorigin attribute
-        img.src = atlasUrl;
 
         img.onload = () => {
           this.atlasImage = img;
@@ -75,6 +74,8 @@ class TexturePack {
           console.error(error.message, err);
           callback(error, null);
         };
+
+        img.src = atlasUrl;
       })
       .catch((error) => {
         // Handle fetch error or JSON parsing error


### PR DESCRIPTION
### Summary:

Fixed a potential race condition in `TexturePack` where the atlas image might load from the browser cache before its `onload` and `onerror` listeners are attached, causing loading to appear to fail. This is fixed by setting the image `src` *after* attaching listeners.

### Changes:

- **Prevented Race Condition in `TexturePack` Image Loading:**
  - In `TexturePack.loadTextures()`, the assignment of `img.src = atlasUrl;` has been moved to *after* the `img.onload` and `img.onerror` event listeners are defined.
  - This ensures that even if the atlas image is served rapidly from the browser cache, the event handlers will be in place to correctly process the load or error state.

- **Simplified `AssetsManager.load()`:**
  - The `AssetsManager.load()` method now directly calls `this.updateTextures()`, `this.updateBackground()`, and `this.updateGrid()` within a `Promise.all()`.
  - This removes redundant promise creation and leverages the existing update methods for initial asset loading, making the code more DRY.