### PR TITLE
fix(renderer): Set default value for `options` in `addEventListener` to prevent error

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1845,7 +1845,7 @@ class Renderer {
    * @param {Object} [options] - Optional parameters, including `onlyAvailable: true` to filter events to available positions only.
    * @throws {Error} - If the event type is invalid.
    */
-  addEventListener(eventType, listener, options) {
+  addEventListener(eventType, listener, options = {}) {
     if (!this._eventListeners[eventType] || eventType.endsWith('Available')) {
       throw new Error('Invalid event type');
     }


### PR DESCRIPTION
### Summary:

Fixed a `TypeError` in the `Renderer.addEventListener` method that occurred when the optional `options` parameter was omitted. The implementation was attempting to access properties on `options` when it was `undefined`. Resolves the issue by providing a default empty object (`{}`) for the `options` parameter, making it truly optional and preventing the error.

### Changes:

- **Assigned Default Value to `options` Parameter:**
  - The method signature for `Renderer.addEventListener` was updated from `(eventType, listener, options)` to `(eventType, listener, options = {})`.
  - This change ensures that if the method is called with only two arguments, `options` is initialized as an empty object, preventing a `TypeError` when the code checks for `options.onlyAvailable`.