### PR TITLE
fix(test): Replace `toThrowError` with `toThrow` in Unit Tests

### DIFF
--- a/tests/board.test.js
+++ b/tests/board.test.js
@@ -42,7 +42,7 @@ describe('Board', () => {
         rows: 4,
         positions: [],
       };
-      expect(() => new Board(invalidMap)).toThrowError('Invalid map provided');
+      expect(() => new Board(invalidMap)).toThrow('Invalid map provided');
     });
 
     it('should throw an error if map is invalid (missing columns)', () => {
@@ -51,7 +51,7 @@ describe('Board', () => {
         rows: 4,
         positions: [],
       };
-      expect(() => new Board(invalidMap)).toThrowError('Invalid map provided');
+      expect(() => new Board(invalidMap)).toThrow('Invalid map provided');
     });
 
     it('should throw an error if map is invalid (missing rows)', () => {
@@ -60,7 +60,7 @@ describe('Board', () => {
         columns: 4,
         positions: [],
       };
-      expect(() => new Board(invalidMap)).toThrowError('Invalid map provided');
+      expect(() => new Board(invalidMap)).toThrow('Invalid map provided');
     });
 
     it('should throw an error if map is invalid (missing positions)', () => {
@@ -69,7 +69,7 @@ describe('Board', () => {
         columns: 4,
         rows: 4,
       };
-      expect(() => new Board(invalidMap)).toThrowError('Invalid map provided');
+      expect(() => new Board(invalidMap)).toThrow('Invalid map provided');
     });
   });
 
@@ -92,8 +92,8 @@ describe('Board', () => {
     });
 
     it('should throw an error if index is out of bounds', () => {
-      expect(() => board.get(-1)).toThrowError('Index out of bounds');
-      expect(() => board.get(board.map.positions.length)).toThrowError(
+      expect(() => board.get(-1)).toThrow('Index out of bounds');
+      expect(() => board.get(board.map.positions.length)).toThrow(
         'Index out of bounds',
       );
     });
@@ -114,17 +114,17 @@ describe('Board', () => {
     });
 
     it('should throw an error if index is out of bounds', () => {
-      expect(() => board.set(-1, piece)).toThrowError('Index out of bounds');
-      expect(() => board.set(board.map.positions.length, piece)).toThrowError(
+      expect(() => board.set(-1, piece)).toThrow('Index out of bounds');
+      expect(() => board.set(board.map.positions.length, piece)).toThrow(
         'Index out of bounds',
       );
     });
 
     it('should throw an error if value is not a Piece instance', () => {
-      expect(() => board.set(0, {})).toThrowError(
+      expect(() => board.set(0, {})).toThrow(
         'Value must be an instance of Piece',
       );
-      expect(() => board.set(0, 'not a piece')).toThrowError(
+      expect(() => board.set(0, 'not a piece')).toThrow(
         'Value must be an instance of Piece',
       );
     });
@@ -183,8 +183,8 @@ describe('Board', () => {
     });
 
     it('should throw an error if index is out of bounds', () => {
-      expect(() => board.place(-1, piece)).toThrowError('Index out of bounds');
-      expect(() => board.place(board.map.positions.length, piece)).toThrowError(
+      expect(() => board.place(-1, piece)).toThrow('Index out of bounds');
+      expect(() => board.place(board.map.positions.length, piece)).toThrow(
         'Index out of bounds',
       );
     });
@@ -192,16 +192,16 @@ describe('Board', () => {
     it('should throw an error if position is already occupied', () => {
       board.place(0, piece);
       const anotherPiece = new Piece(['green', 'yellow']);
-      expect(() => board.place(0, anotherPiece)).toThrowError(
+      expect(() => board.place(0, anotherPiece)).toThrow(
         'Position already occupied',
       );
     });
 
     it('should throw an error if value is not a Piece instance', () => {
-      expect(() => board.place(0, {})).toThrowError(
+      expect(() => board.place(0, {})).toThrow(
         'Value must be an instance of Piece',
       );
-      expect(() => board.place(0, 'not a piece')).toThrowError(
+      expect(() => board.place(0, 'not a piece')).toThrow(
         'Value must be an instance of Piece',
       );
     });
@@ -228,8 +228,8 @@ describe('Board', () => {
     });
 
     it('should throw an error if index is out of bounds', () => {
-      expect(() => board.remove(-1)).toThrowError('Index out of bounds');
-      expect(() => board.remove(board.map.positions.length)).toThrowError(
+      expect(() => board.remove(-1)).toThrow('Index out of bounds');
+      expect(() => board.remove(board.map.positions.length)).toThrow(
         'Index out of bounds',
       );
     });
@@ -276,12 +276,12 @@ describe('Board', () => {
     });
 
     it('should throw an error if index is out of bounds', () => {
-      expect(() => board.getRelatedHexagons(-1)).toThrowError(
+      expect(() => board.getRelatedHexagons(-1)).toThrow(
         'Index out of bounds',
       );
       expect(() =>
         board.getRelatedHexagons(board.map.positions.length),
-      ).toThrowError('Index out of bounds');
+      ).toThrow('Index out of bounds');
     });
   });
 
@@ -445,10 +445,10 @@ describe('Board', () => {
     });
 
     it('should throw an error if value is not a Piece instance', () => {
-      expect(() => board.getHexagonPositions({})).toThrowError(
+      expect(() => board.getHexagonPositions({})).toThrow(
         'Value must be an instance of Piece',
       );
-      expect(() => board.getHexagonPositions('not a piece')).toThrowError(
+      expect(() => board.getHexagonPositions('not a piece')).toThrow(
         'Value must be an instance of Piece',
       );
     });
@@ -488,19 +488,19 @@ describe('Board', () => {
     });
 
     it('should throw an error if index is out of bounds', () => {
-      expect(() => board.getHexagonsFormed(-1, piece)).toThrowError(
+      expect(() => board.getHexagonsFormed(-1, piece)).toThrow(
         'Index out of bounds',
       );
       expect(() =>
         board.getHexagonsFormed(board.map.positions.length, piece),
-      ).toThrowError('Index out of bounds');
+      ).toThrow('Index out of bounds');
     });
 
     it('should throw an error if value is not a Piece instance', () => {
-      expect(() => board.getHexagonsFormed(0, {})).toThrowError(
+      expect(() => board.getHexagonsFormed(0, {})).toThrow(
         'Value must be an instance of Piece',
       );
-      expect(() => board.getHexagonsFormed(0, 'not a piece')).toThrowError(
+      expect(() => board.getHexagonsFormed(0, 'not a piece')).toThrow(
         'Value must be an instance of Piece',
       );
     });
@@ -522,19 +522,19 @@ describe('Board', () => {
     });
 
     it('should throw an error if index is out of bounds', () => {
-      expect(() => board.countHexagonsFormed(-1, piece)).toThrowError(
+      expect(() => board.countHexagonsFormed(-1, piece)).toThrow(
         'Index out of bounds',
       );
       expect(() =>
         board.countHexagonsFormed(board.map.positions.length, piece),
-      ).toThrowError('Index out of bounds');
+      ).toThrow('Index out of bounds');
     });
 
     it('should throw an error if value is not a Piece instance', () => {
-      expect(() => board.countHexagonsFormed(0, {})).toThrowError(
+      expect(() => board.countHexagonsFormed(0, {})).toThrow(
         'Value must be an instance of Piece',
       );
-      expect(() => board.countHexagonsFormed(0, 'not a piece')).toThrowError(
+      expect(() => board.countHexagonsFormed(0, 'not a piece')).toThrow(
         'Value must be an instance of Piece',
       );
     });
@@ -559,8 +559,8 @@ describe('Board', () => {
     });
 
     it('should throw an error if index is out of bounds', () => {
-      expect(() => board.isEmpty(-1)).toThrowError('Index out of bounds');
-      expect(() => board.isEmpty(board.map.positions.length)).toThrowError(
+      expect(() => board.isEmpty(-1)).toThrow('Index out of bounds');
+      expect(() => board.isEmpty(board.map.positions.length)).toThrow(
         'Index out of bounds',
       );
     });
@@ -596,16 +596,16 @@ describe('Board', () => {
     });
 
     it('should throw an error if column or row is out of bounds', () => {
-      expect(() => board.isCompleteHexagon(-1, 0)).toThrowError(
+      expect(() => board.isCompleteHexagon(-1, 0)).toThrow(
         'Column or row out of bounds',
       );
-      expect(() => board.isCompleteHexagon(0, -1)).toThrowError(
+      expect(() => board.isCompleteHexagon(0, -1)).toThrow(
         'Column or row out of bounds',
       );
-      expect(() => board.isCompleteHexagon(board.map.columns, 0)).toThrowError(
+      expect(() => board.isCompleteHexagon(board.map.columns, 0)).toThrow(
         'Column or row out of bounds',
       );
-      expect(() => board.isCompleteHexagon(0, board.map.rows)).toThrowError(
+      expect(() => board.isCompleteHexagon(0, board.map.rows)).toThrow(
         'Column or row out of bounds',
       );
     });
@@ -777,7 +777,7 @@ describe('Board', () => {
 
       it('should throw an error for an invalid event type', () => {
         const listener = jest.fn();
-        expect(() => board.addEventListener('invalid', listener)).toThrowError(
+        expect(() => board.addEventListener('invalid', listener)).toThrow(
           'Invalid event type',
         );
       });
@@ -796,7 +796,7 @@ describe('Board', () => {
         const listener = jest.fn();
         expect(() =>
           board.removeEventListener('invalid', listener),
-        ).toThrowError('Invalid event type');
+        ).toThrow('Invalid event type');
       });
     });
 

--- a/tests/hexGrid.test.js
+++ b/tests/hexGrid.test.js
@@ -23,7 +23,7 @@ describe('HexGrid', () => {
     });
 
     it('should throw an error if the grid type is invalid', () => {
-      expect(() => new HexGrid(2, 2, 'invalid-type')).toThrowError(
+      expect(() => new HexGrid(2, 2, 'invalid-type')).toThrow(
         'Invalid grid type',
       );
     });

--- a/tests/piece.test.js
+++ b/tests/piece.test.js
@@ -25,61 +25,61 @@ describe('Piece', () => {
     });
 
     it('should throw an error if colors is not an array', () => {
-      expect(() => new Piece('red-blue')).toThrowError(
+      expect(() => new Piece('red-blue')).toThrow(
         'colors must be an array of strings',
       );
-      expect(() => new Piece({})).toThrowError(
+      expect(() => new Piece({})).toThrow(
         'colors must be an array of strings',
       );
-      expect(() => new Piece(123)).toThrowError(
+      expect(() => new Piece(123)).toThrow(
         'colors must be an array of strings',
       );
     });
 
     it('should throw an error if colors array does not have exactly 2 elements', () => {
-      expect(() => new Piece(['red'])).toThrowError(
+      expect(() => new Piece(['red'])).toThrow(
         'colors must be an array of 2 strings representing the colors of the piece',
       );
-      expect(() => new Piece(['red', 'blue', 'green'])).toThrowError(
+      expect(() => new Piece(['red', 'blue', 'green'])).toThrow(
         'colors must be an array of 2 strings representing the colors of the piece',
       );
-      expect(() => new Piece([])).toThrowError(
+      expect(() => new Piece([])).toThrow(
         'colors must be an array of 2 strings representing the colors of the piece',
       );
     });
 
     it('should throw an error if colors array contains non-string elements', () => {
-      expect(() => new Piece(['red', 123])).toThrowError(
+      expect(() => new Piece(['red', 123])).toThrow(
         'colors must be an array of strings',
       );
-      expect(() => new Piece([123, 'blue'])).toThrowError(
+      expect(() => new Piece([123, 'blue'])).toThrow(
         'colors must be an array of strings',
       );
-      expect(() => new Piece([{}, 'blue'])).toThrowError(
+      expect(() => new Piece([{}, 'blue'])).toThrow(
         'colors must be an array of strings',
       );
-      expect(() => new Piece(['red', {}])).toThrowError(
+      expect(() => new Piece(['red', {}])).toThrow(
         'colors must be an array of strings',
       );
-      expect(() => new Piece([null, 'blue'])).toThrowError(
+      expect(() => new Piece([null, 'blue'])).toThrow(
         'colors must be an array of strings',
       );
-      expect(() => new Piece(['red', null])).toThrowError(
+      expect(() => new Piece(['red', null])).toThrow(
         'colors must be an array of strings',
       );
     });
 
     it('should throw an error if params is not an object', () => {
-      expect(() => new Piece(['red', 'blue'], 'string param')).toThrowError(
+      expect(() => new Piece(['red', 'blue'], 'string param')).toThrow(
         'params must be an object',
       );
-      expect(() => new Piece(['red', 'blue'], 123)).toThrowError(
+      expect(() => new Piece(['red', 'blue'], 123)).toThrow(
         'params must be an object',
       );
-      expect(() => new Piece(['red', 'blue'], [])).toThrowError(
+      expect(() => new Piece(['red', 'blue'], [])).toThrow(
         'params must be an object',
       );
-      expect(() => new Piece(['red', 'blue'], null)).not.toThrowError(
+      expect(() => new Piece(['red', 'blue'], null)).not.toThrow(
         'params must be an object',
       );
     });
@@ -177,7 +177,7 @@ describe('Piece', () => {
 
     it('should throw an error if colors is missing in the JSON representation', () => {
       const json = { customProperties: { name: 'Test Piece', value: 15 } };
-      expect(() => Piece.fromJSON(json)).toThrowError(
+      expect(() => Piece.fromJSON(json)).toThrow(
         'colors must be an array of strings',
       );
     });
@@ -187,7 +187,7 @@ describe('Piece', () => {
         colors: ['red'],
         customProperties: { name: 'Test Piece', value: 15 },
       };
-      expect(() => Piece.fromJSON(json)).toThrowError(
+      expect(() => Piece.fromJSON(json)).toThrow(
         'colors must be an array of 2 strings representing the colors of the piece',
       );
     });

--- a/tests/triHexGrid.test.js
+++ b/tests/triHexGrid.test.js
@@ -48,10 +48,10 @@ describe('TriHexGrid', () => {
     });
 
     it('should throw an error if the triangle index is invalid', () => {
-      expect(() => grid.get(1, 1, 0)).toThrowError(
+      expect(() => grid.get(1, 1, 0)).toThrow(
         'Triangle index must be between 1 and 6',
       );
-      expect(() => grid.get(1, 1, 7)).toThrowError(
+      expect(() => grid.get(1, 1, 7)).toThrow(
         'Triangle index must be between 1 and 6',
       );
     });
@@ -75,10 +75,10 @@ describe('TriHexGrid', () => {
     });
 
     it('should not set the value if the triangle index is invalid', () => {
-      expect(() => grid.set([[0, 0, 0]], 'value')).toThrowError(
+      expect(() => grid.set([[0, 0, 0]], 'value')).toThrow(
         'Triangle index must be between 1 and 6',
       );
-      expect(() => grid.set([[0, 0, 7]], 'value')).toThrowError(
+      expect(() => grid.set([[0, 0, 7]], 'value')).toThrow(
         'Triangle index must be between 1 and 6',
       );
     });
@@ -153,10 +153,10 @@ describe('TriHexGrid', () => {
     });
 
     it('should throw an error if the triangle index is invalid', () => {
-      expect(() => grid.remove([[2, 2, 0]])).toThrowError(
+      expect(() => grid.remove([[2, 2, 0]])).toThrow(
         'Triangle index must be between 1 and 6',
       );
-      expect(() => grid.remove([[2, 2, 7]])).toThrowError(
+      expect(() => grid.remove([[2, 2, 7]])).toThrow(
         'Triangle index must be between 1 and 6',
       );
     });


### PR DESCRIPTION
### Summary:

All instances of `.toThrowError()` across the entire test suite have been systematically replaced with the more general `.toThrow()` alias. This change ensures the test suite can run reliably without altering the core assertion logic.

### Changes:

- **Standardized Error Assertion in Tests:**
  - Replaced all occurrences of `.toThrowError()` with `.toThrow()` in the following test files:
    - `tests/board.test.js`
    - `tests/hexGrid.test.js`
    - `tests/piece.test.js`
    - `tests/triHexGrid.test.js`
  - This is a direct replacement, and the expected error messages passed to the matcher remain the same, preserving the integrity of the tests.