### PR TITLE
fix(renderer): Correct Argument Passing for Hexagon Coordinate Retrieval

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1162,7 +1162,7 @@ class Renderer {
 
     const { image: textureImage, definition, scale = 1 } = texture;
 
-    const [x, y] = this._getHexagonCoordinates(coordinate);
+    const [x, y] = this._getHexagonCoordinates(...coordinate);
     const imageWidth = definition.w;
     const imageHeight = definition.h;
 


### PR DESCRIPTION
### Summary:

Fixed a runtime error in the `_renderHexagon` method caused by incorrect argument passing to its helper, `_getHexagonCoordinates`. The helper function expects two arguments, `col` and `row`, but was being called with a single array `[col, row]`. Uses the spread operator (`...`) to correctly unpack the coordinate array, ensuring the arguments are passed as expected and resolving the rendering failure.

### Changes:

- **Corrected Argument Spreading in `_renderHexagon`:**
  - In `src/renderer.js`, within the `_renderHexagon` method, the call to `_getHexagonCoordinates` has been updated.
  - The function call was changed from `this._getHexagonCoordinates(coordinate)` to `this._getHexagonCoordinates(...coordinate)`.
  - This ensures the `[col, row]` array stored in the `coordinate` variable is correctly unpacked into two separate arguments (`col`, `row`) as the helper method's signature requires.