### PR TITLE
feat(renderer): Expand Event Listener Support for Pointer, Mouse, Drag, and Touch Interactions

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2082,13 +2082,17 @@ addEventListener(eventType, listener, options = {});
 
 **Description:**
 
-Adds an event listener for specific renderer interaction events (drag/drop, mouse move, click) or resize events.
+Adds an event listener for renderer interaction events (pointer, mouse, drag/drop, touch, or resize events).
 
 **Parameters:**
 
-- `eventType` (string): The type of event to listen for:
-  - `'dragover'`, `'drop'`, `'mousemove'`, `'click'`: Triggered for interactions anywhere on the canvas. The listener receives the index of the piece at the event coordinates (-1 if none).
-  - `'resize'`: Triggered when the container element is resized. The listener receives an object with canvas and container dimensions.
+- `eventType` (string): The type of event to listen for. Supported event types:
+  - `'click'`, `'dblclick'`, `'mousedown'`, `'mousemove'`, `'mouseup'`
+  - `'dragenter'`, `'dragover'`, `'dragleave'`, `'drop'`
+  - `'touchstart'`, `'touchmove'`, `'touchend'`, `'touchcancel'`
+  - `'resize'`
+  - For pointer/mouse/touch/drag events: The listener receives the index of the piece at the event coordinates (`-1` if none).
+  - For `'resize'`: The listener receives an object with canvas and container dimensions.
 - `listener` (Function): The function to execute when the event occurs. Receives event-specific arguments (usually the piece index or dimension info).
 - `options` (Object, optional): Optional parameters.
   - `onlyAvailable` (boolean): If `true`, the listener will only be triggered for drop events on available positions. Defaults to `false`. This is useful for distinguishing between general drop events and those specifically on available positions. (`resize` events do not use this option.)
@@ -2137,7 +2141,11 @@ Removes a previously added event listener for a specific renderer event type.
 
 **Parameters:**
 
-- `eventType` (string): The event type from which to remove the listener.
+- `eventType` (string): The event type from which to remove the listener. Supported event types:
+  - `'click'`, `'dblclick'`, `'mousedown'`, `'mousemove'`, `'mouseup'`
+  - `'dragenter'`, `'dragover'`, `'dragleave'`, `'drop'`
+  - `'touchstart'`, `'touchmove'`, `'touchend'`, `'touchcancel'`
+  - `'resize'`
 - `listener` (Function): The listener function that was originally added.
 
 **Throws:**

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -646,10 +646,19 @@ class Renderer {
    */
   _initEventListeners() {
     const eventConfigs = [
-      { type: 'dragover', preventDefault: true },
-      { type: 'drop', preventDefault: true },
       { type: 'click', preventDefault: false },
+      { type: 'dblclick', preventDefault: false },
+      { type: 'mousedown', preventDefault: false },
       { type: 'mousemove', preventDefault: false },
+      { type: 'mouseup', preventDefault: false },
+      { type: 'dragenter', preventDefault: true },
+      { type: 'dragover', preventDefault: true },
+      { type: 'dragleave', preventDefault: true },
+      { type: 'drop', preventDefault: true },
+      { type: 'touchstart', preventDefault: true },
+      { type: 'touchmove', preventDefault: true },
+      { type: 'touchend', preventDefault: true },
+      { type: 'touchcancel', preventDefault: true },
     ];
 
     eventConfigs.forEach(({ type, preventDefault }) => {
@@ -1893,7 +1902,7 @@ class Renderer {
 
   /**
    * @method addEventListener - Adds an event listener for a specific event type.
-   * @param {string} eventType - The event type to listen for (dragover, drop, mousemove, click, resize).
+   * @param {string} eventType - The event type to listen for.
    * @param {Function} listener - The callback function to be executed when the event is triggered.
    * @param {Object} [options] - Optional parameters, including `onlyAvailable: true` to filter events to available positions only.
    * @throws {Error} - If the event type is invalid.
@@ -1912,7 +1921,7 @@ class Renderer {
 
   /**
    * @method removeEventListener - Removes an event listener for a specific event type.
-   * @param {string} eventType - The event type to stop listening for (dragover, drop, mousemove, click, resize).
+   * @param {string} eventType - The event type to stop listening for.
    * @param {Function} listener - The callback function to be removed.
    * @throws {Error} - If the event type is invalid.
    */


### PR DESCRIPTION
### Summary:

Enhances the renderer's event system by expanding the range of supported event types in `addEventListener`. Previously limited to a few specific events, the renderer now handles a comprehensive set of standard browser interaction events, including detailed mouse (`mousedown`, `mouseup`, `dblclick`), drag-and-drop (`dragenter`, `dragleave`), and touch (`touchstart`, `touchmove`, `touchend`) events. This provides developers with finer-grained control to build more complex and custom user interactions.

### Changes:

- **Expanded Event Listener Capabilities:**
  - The `_initEventListeners` method in `renderer.js` has been updated to attach listeners for a wider range of events.
  - Newly supported events include:
    - **Mouse Events:** `dblclick`, `mousedown`, `mouseup`
    - **Drag & Drop Events:** `dragenter`, `dragleave`
    - **Touch Events:** `touchstart`, `touchmove`, `touchend`, `touchcancel`
  - All new pointer, mouse, touch, and drag events correctly resolve the piece index at the event's coordinates and pass it to the listener function.

- **Updated API Documentation:**
  - The `addEventListener` and `removeEventListener` sections in `API.md` have been updated.
  - The list of supported `eventType` values now includes all the newly added events, providing a clear reference for developers.